### PR TITLE
Add `location` global

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -1,5 +1,5 @@
 if(getRversion() >= "2.15.1") {
-  utils::globalVariables(c(".", "year", "month"))
+  utils::globalVariables(c(".", "year", "month", "location"))
 }
 
 #' @import dplyr


### PR DESCRIPTION
Hi there, we are working on the next version of dplyr and your package was flagged in our reverse dependency checks.

We have removed the defunct function `dplyr::location()`.

Your package does one of two things:

- It re-exports `dplyr::location()`, which has been defunct for many years and has now been removed from dplyr.

- It references a column named `location`, likely in a `mutate()` or `summarise()`, but does not note this as a global variable with `utils::globalVariables("location")`. In this case, you got lucky that dplyr exported `location()`, meaning that you did not need a global variable for `"location"`. Since we have removed `dplyr::location()`, your package will need this now.

dplyr will be released on January 31, 2026. If you could please send an update of your package to CRAN before then, that would help us out a lot! Thanks!